### PR TITLE
Adding fix for null matches in path

### DIFF
--- a/dropfile.js
+++ b/dropfile.js
@@ -60,7 +60,7 @@ if (!window.Silverlight) window.Silverlight = {}; Silverlight._silverlightCount 
     var path = (function (){
         var s = document.getElementsByTagName('script'),
         p = s[s.length-1];
-        return (p.src?p.src:p.getAttribute('src')).match(/(.*\/)/)[0] || "";
+        return ((p.src?p.src:p.getAttribute('src')).match(/(.*\/)/) || [""])[0];
 	})();
 
     /**


### PR DESCRIPTION
This resolves a bug in the demo in IE7, which fails because dropfile.js wants the first array index of a null value.  It is unsafe to check for the first index of a potentially null value.

This is a very small change. Afterward, if you are interested, fix (or let me fix) the other instances where an index is unsafely called on match.
