### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,7 +43,7 @@ dropfile.js is a shim/polyfill for adding support for dragging files from the de
 
 # Working with jQuery
 
-jQuery and other API's, wrap the original javascript event object and makes it available at e.originalEvent. This script does not recognise jQuery but does recognise the ondrop event that was assigned by jQuery and will execute that when used. However now the original event object is passed to the handler not the wrapped up event object used in jQuery. But not to worry its easy to write code which can accomodate both approaches. See http://mrswitch.github.com/dropfile/demo-jquery.htm
+jQuery and other API's, wrap the original javascript event object and makes it available at e.originalEvent. This script does not recognise jQuery but does recognise the ondrop event that was assigned by jQuery and will execute that when used. However now the original event object is passed to the handler not the wrapped up event object used in jQuery. But not to worry its easy to write code which can accommodate both approaches. See http://mrswitch.github.com/dropfile/demo-jquery.htm
 
 
 # Browser Support


### PR DESCRIPTION
MrSwitch, I've corrected a typographical error in the documentation of the [dropfile](https://github.com/MrSwitch/dropfile) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
